### PR TITLE
Move diff and update to directly call Pulumi APIs, instead of shelling out to the CLI tool

### DIFF
--- a/console/main.go
+++ b/console/main.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
 )
 
 const pulumiDir = "/Users/josh/go/src/github.com/cockroachdb/pulumi-poc/template"
 
 func readHandler(w http.ResponseWriter, r *http.Request) {
+	// Haven't figured out how to get direct access to this API. With that said,
+	// not totally clear how much we'd use Pulumi config, since can use the
+	// managed console DB instead.
 	c := exec.Command("pulumi", "config", "get", "whitelist")
 	c.Dir = pulumiDir
 	out, err := c.CombinedOutput()
@@ -37,21 +41,19 @@ func prepareHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func diffHandler(w http.ResponseWriter, r *http.Request) {
-	c := exec.Command("pulumi", "preview", "--diff")
-	c.Dir = pulumiDir
-	out, err := c.CombinedOutput()
+	// Call API directly.
+	plan, err := DiffOrUpdate(true /*dryrun*/)
 	if err != nil {
 		fmt.Println(err)
 	}
 
 	fmt.Fprintf(w, "Here's the plan!\n")
-	fmt.Fprint(w, string(out))
+	fmt.Fprint(w, plan)
 }
 
 func writeHandler(w http.ResponseWriter, r *http.Request) {
-	c := exec.Command("pulumi", "up", "--yes")
-	c.Dir = pulumiDir
-	err := c.Run()
+	// Call API directly.
+	_, err := DiffOrUpdate(false /*dryrun*/)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -60,6 +62,10 @@ func writeHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	// Fetching the current project requires reading a YAML file. Ideally, we'd
+	// remove this dependency.
+	os.Chdir(pulumiDir)
+
 	http.HandleFunc("/read", readHandler)
 	http.HandleFunc("/prepare", prepareHandler)
 	http.HandleFunc("/diff", diffHandler)

--- a/console/pulumi.go
+++ b/console/pulumi.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/backend"
+	"github.com/pulumi/pulumi/pkg/backend/display"
+	"github.com/pulumi/pulumi/pkg/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/diag/colors"
+	"github.com/pulumi/pulumi/pkg/engine"
+	"github.com/pulumi/pulumi/pkg/util/cancel"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/util/result"
+	"github.com/pulumi/pulumi/pkg/workspace"
+)
+
+// Copied from Pulumi souce code and modified.
+func loginAndGetBackend(opts display.Options) (backend.Backend, error) {
+	// I guess eventually these creds would have to be stored in vault??
+	creds, err := workspace.GetStoredCredentials()
+	if err != nil {
+		return nil, err
+	}
+	return httpstate.Login(context.TODO(), cmdutil.Diag(), creds.Current, "", opts)
+}
+
+// Copied from Pulumi souce code and modified.
+func loginAndGetStack(
+	stackName string, opts display.Options) (backend.Stack, error) {
+	b, err := loginAndGetBackend(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	stackRef, err := b.ParseStackReference(stackName)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := b.GetStack(context.TODO(), stackRef)
+	if err != nil {
+		return nil, err
+	}
+	if stack != nil {
+		return stack, err
+	}
+
+	return nil, errors.Errorf("no stack named '%s' found", stackName)
+}
+
+// Copied from Pulumi source code, since not all parts are exported. Maybe there
+// is a better way...
+type cancellationScope struct {
+	context *cancel.Context
+	sigint  chan os.Signal
+	done    chan bool
+}
+
+func (s *cancellationScope) Context() *cancel.Context {
+	return s.context
+}
+
+func (s *cancellationScope) Close() {
+	signal.Stop(s.sigint)
+	close(s.sigint)
+	<-s.done
+}
+
+type cancellationScopeSource int
+
+var cancellationScopes = backend.CancellationScopeSource(cancellationScopeSource(0))
+
+func (cancellationScopeSource) NewScope(events chan<- engine.Event, isPreview bool) backend.CancellationScope {
+	cancelContext, cancelSource := cancel.NewContext(context.Background())
+
+	c := &cancellationScope{
+		context: cancelContext,
+		sigint:  make(chan os.Signal),
+		done:    make(chan bool),
+	}
+
+	go func() {
+		for range c.sigint {
+			// If we haven't yet received a SIGINT, call the cancellation func. Otherwise call the termination
+			// func.
+			if cancelContext.CancelErr() == nil {
+				message := "^C received; cancelling. If you would like to terminate immediately, press ^C again.\n"
+				if !isPreview {
+					message += colors.BrightRed + "Note that terminating immediately may lead to orphaned resources " +
+						"and other inconsistencies.\n" + colors.Reset
+				}
+				events <- engine.Event{
+					Type: engine.StdoutColorEvent,
+					Payload: engine.StdoutEventPayload{
+						Message: message,
+						Color:   colors.Always,
+					},
+				}
+
+				cancelSource.Cancel()
+			} else {
+				message := colors.BrightRed + "^C received; terminating" + colors.Reset
+				events <- engine.Event{
+					Type: engine.StdoutColorEvent,
+					Payload: engine.StdoutEventPayload{
+						Message: message,
+						Color:   colors.Always,
+					},
+				}
+
+				cancelSource.Terminate()
+			}
+		}
+		close(c.done)
+	}()
+	signal.Notify(c.sigint, os.Interrupt)
+
+	return c
+}
+
+func DiffOrUpdate(dryrun bool) (string, error) {
+	opts := backend.UpdateOptions{
+		Engine: engine.UpdateOptions{},
+		AutoApprove: true,
+		Display: display.Options{
+			Color: colors.Always,
+		},
+	}
+
+	// Login to Pulumi service and get stack. Eventually there would be 1+
+	// stack(s) per customer cluster.
+	s, err := loginAndGetStack("joshimhoff/poc/dev", opts.Display)
+	if err != nil {
+		return "", err
+	}
+	p := &workspace.Project{
+		Name: "poc",
+		Runtime: workspace.NewProjectRuntimeInfo("go", map[string]interface{}{}),
+	}
+
+	// What is returned from this API is NOT a detailed plan, despite its name.
+	// As a side effect of calling s.Preview, a detailed plan is logged to
+	// stdout. Not sure what best way of getting at the plan is yet.
+	var changes engine.ResourceChanges
+	var res result.Result
+	if dryrun {
+		changes, res = s.Preview(context.TODO(), backend.UpdateOperation{
+			Proj:   p,
+			Root:   pulumiDir,
+			M:      &backend.UpdateMetadata{},
+			Opts:   opts,
+			Scopes: cancellationScopes,
+		})
+	} else {
+		changes, res = s.Update(context.TODO(), backend.UpdateOperation{
+			Proj:   p,
+			Root:   pulumiDir,
+			M:      &backend.UpdateMetadata{},
+			Opts:   opts,
+			Scopes: cancellationScopes,
+		})
+	}
+	if res != nil {
+		return "", res.Error()
+	}
+	return fmt.Sprintf("%+v", changes), nil
+}

--- a/template/Pulumi.dev.yaml
+++ b/template/Pulumi.dev.yaml
@@ -1,3 +1,3 @@
 config:
   gcp:project: playing-with-pulumi
-  poc:whitelist: 99.108.106.120/32
+  poc:whitelist: 3.1.1.0/24


### PR DESCRIPTION
More experimenting. Went thru Pulumi code with a debugger on Friday. Not that hairy to make direct API calls in the end, though I have done some ugly code copying to get it working. I am also not sure which of the Pulumi APIs are stable and which aren't.

Some other issues:

1. Preview() prints the resource change plan and returns something of type engine.ResourceChanges. Unforrunately, engine.ResourceChanges is not detailed enough to do programmatic safety checks. How do we get programmatic access to something to diff against?
2. Right now we are depending on a YAML file that gives details on the Pulumi project (template/Pulumi.yaml). I think it's possible to remove this dep but I am not sure exactly how right now.
3. This is a longer term thing but the two binary architecture still exists. This means the sidecar process that runs golang Pulumi template code still must be running. Joe from Pulumi says it is possible to get down to one binary (and thus remove the sidecar) but we might need help from them as it is probably not obvious how to do it.